### PR TITLE
chore: 🔧 update github actions workflow

### DIFF
--- a/.github/workflows/pr-develop-to-main.yml
+++ b/.github/workflows/pr-develop-to-main.yml
@@ -1,13 +1,16 @@
 name: Crear PR de develop a main
 
 on:
-  push:
+  pull_request:
     branches:
       - develop
+    types:
+      - closed
 
 jobs:
   create-pr:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true  # Asegura que el PR ha sido fusionado
     steps:
       - name: Clonar el repositorio
         uses: actions/checkout@v3


### PR DESCRIPTION
updated github actions workflow to trigger on pull request merge instead of push to develop branch. this ensures that the workflow only creates a pull request to main when a pull request from develop has been
merged.